### PR TITLE
fail properly when the library doesn't load

### DIFF
--- a/lib/resty/nettle/library.lua
+++ b/lib/resty/nettle/library.lua
@@ -60,4 +60,4 @@ local function L()
     return nil, "unable to load nettle"
 end
 
-return L()
+return assert(L())


### PR DESCRIPTION
the nil+err return value returns nil to require. Which causes
require to insert a boolean true value. Actual usage later will then
cause a "indexing a boolean value" error

fixes #22