### PR TITLE
chore(*) release 1.3

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,13 @@
 
 All notable changes to `lua-resty-nettle` will be documented in this file.
 
+## [1.3] - 2020-03-27
+### Fixed
+- Fix RSA to pass the right known length to mpz.tostring() on signing
+
+### Changed
+- No need to give length to ecc scalar:d()
+
 ## [1.2] - 2020-03-26
 ### Added
 - Support for `pbkdf2.hmac_gosthash94cp`

--- a/lib/resty/nettle.lua
+++ b/lib/resty/nettle.lua
@@ -1,5 +1,5 @@
 return {
-  _VERSION            = "1.2",
+  _VERSION            = "1.3",
   aes                 = require "resty.nettle.aes",
   arcfour             = require "resty.nettle.arcfour",
   base16              = require "resty.nettle.base16",

--- a/lib/resty/nettle/ecc.lua
+++ b/lib/resty/nettle/ecc.lua
@@ -122,6 +122,8 @@ function scalar.new(c, z)
 
   c = c or curves["P-256"]
 
+  local size = curve_sizes[c]
+
   if type(c) == "cdata" then
     hogweed.nettle_ecc_scalar_init(ctx, c)
   elseif curves[c] then
@@ -138,13 +140,13 @@ function scalar.new(c, z)
     end
   end
 
-  return setmetatable({ context = ctx }, scalar)
+  return setmetatable({ context = ctx, size = size }, scalar)
 end
 
 
-function scalar:d(len)
+function scalar:d()
   hogweed.nettle_ecc_scalar_get(self.context, mpz_t_1)
-  return mpz.tostring(mpz_t_1, len)
+  return mpz.tostring(mpz_t_1, self.size)
 end
 
 local ecc = { point = point, scalar = scalar, curve = curve }

--- a/lib/resty/nettle/rsa.lua
+++ b/lib/resty/nettle/rsa.lua
@@ -232,7 +232,7 @@ function rsa:sign_digest(digest)
     return nil, "supported RSA digests for signing are MD5, SHA1, SHA256, and SHA512"
   end
 
-  return mpz.tostring(sig)
+  return mpz.tostring(sig, l * 8)
 end
 
 function rsa:sign_digest_tr(digest)
@@ -269,7 +269,7 @@ function rsa:sign_digest_tr(digest)
     return nil, "supported RSA digests with blinding are MD5, SHA1, SHA256, and SHA512"
   end
 
-  return mpz.tostring(sig)
+  return mpz.tostring(sig, l * 8)
 end
 
 function rsa:verify_digest(digest, signature)
@@ -327,7 +327,7 @@ function rsa:pss_sign_digest(digest)
     return nil, "supported RSA-PSS digests for signing are SHA256, SHA384, and SHA512"
   end
 
-  return mpz.tostring(sig)
+  return mpz.tostring(sig, l * 8)
 end
 
 function rsa:pss_verify_digest(digest, signature)


### PR DESCRIPTION
### Fixed
- Fix RSA to pass the right known length to mpz.tostring() on signing

### Changed
- No need to give length to ecc scalar:d()