### PR TITLE
chore(*) release 2.1

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,14 @@
 All notable changes to `lua-resty-nettle` will be documented in this file.
 
 
-## [2.0] - 2020-04-06
+## [2.1] - 2021-04-07
+
+### Added
+- Publish `resty.nettle.eddsa` module with `resty.nettle` module
+- Make `resty.nettle.eddsa` to automatically choose the algorithm based on key size
+
+
+## [2.0] - 2021-04-06
 ### Added
 - Add Streebog hashing algorithms (256 and 512)
 - Add PBKDF2 HMAC-SHA384 and HMAC-SHA512 variants

--- a/lib/resty/nettle.lua
+++ b/lib/resty/nettle.lua
@@ -1,5 +1,5 @@
 return {
-  _VERSION            = "2.0",
+  _VERSION            = "2.1",
   aes                 = require "resty.nettle.aes",
   arcfour             = require "resty.nettle.arcfour",
   arctwo              = require "resty.nettle.arctwo",

--- a/lib/resty/nettle.lua
+++ b/lib/resty/nettle.lua
@@ -23,6 +23,7 @@ return {
   ["ed448-shake256"]  = require "resty.nettle.ed448-shake256",
   ed25519_sha512      = require "resty.nettle.ed25519-sha512",
   ["ed25519-sha512"]  = require "resty.nettle.ed25519-sha512",
+  eddsa               = require "resty.nettle.eddsa",
   gmp                 = require "resty.nettle.gmp",
   gosthash94          = require "resty.nettle.gosthash94",
   gosthash94cp        = require "resty.nettle.gosthash94cp",

--- a/lib/resty/nettle/ed25519-sha512.lua
+++ b/lib/resty/nettle/ed25519-sha512.lua
@@ -5,25 +5,30 @@ local hogweed = require "resty.nettle.hogweed"
 local ffi = require "ffi"
 local ffi_str = ffi.string
 
-local ed = {}
+local ed25519 = {}
 
-function ed.public_key(pri)
+function ed25519.public_key(pri)
+  if not pri then
+    return nil, "the EdDSA25519 SHA-512 public key cannot be extracted without private key"
+  end
   if #pri ~= 32 then
-    return nil, "the EdDSA25519 SHA-512 supported key size is 256 bits"
+    return nil, "the EdDSA25519 SHA-512 supported private key size is 256 bits"
   end
   hogweed.nettle_ed25519_sha512_public_key(types.uint8_t_32, pri)
   return ffi_str(types.uint8_t_32, 32)
 end
 
-function ed.sign(pub, pri, msg)
-  if pri and not pub then
+function ed25519.sign(pub, pri, msg)
+  if not pri then
+    return nil, "the EdDSA25519 SHA-512 signing is not possible without private key"
+  end
+  if not pub then
     local err
-    pub, err = ed.public_key(pri)
+    pub, err = ed25519.public_key(pri)
     if not pub then
       return nil, err
     end
   end
-
   if #pub ~= 32 then
     return nil, "the EdDSA25519 SHA-512 supported public key size is 256 bits"
   end
@@ -34,7 +39,13 @@ function ed.sign(pub, pri, msg)
   return ffi_str(types.uint8_t_64, 64)
 end
 
-function ed.verify(pub, msg, sig)
+function ed25519.verify(pub, msg, sig)
+  if not pub then
+    return nil, "the EdDSA25519 SHA-512 signature verification is not possible without public key"
+  end
+  if not sig then
+    return nil, "the EdDSA25519 SHA-512 signature verification is not possible without signature"
+  end
   if #pub ~= 32 then
     return nil, "the EdDSA25519 SHA-512 supported public key size is 256 bits"
   end
@@ -47,4 +58,4 @@ function ed.verify(pub, msg, sig)
   return true
 end
 
-return ed
+return ed25519

--- a/lib/resty/nettle/ed448-shake256.lua
+++ b/lib/resty/nettle/ed448-shake256.lua
@@ -5,20 +5,26 @@ local hogweed = require "resty.nettle.hogweed"
 local ffi = require "ffi"
 local ffi_str = ffi.string
 
-local ed = {}
+local ed448 = {}
 
-function ed.public_key(pri)
+function ed448.public_key(pri)
+  if not pri then
+    return nil, "the EdDSA448 SHAKE-256 public key cannot be extracted without private key"
+  end
   if #pri ~= 57 then
-    return nil, "the EdDSA448 SHAKE-256 supported key size is 456 bits"
+    return nil, "the EdDSA448 SHAKE-256 supported private key size is 456 bits"
   end
   hogweed.nettle_ed448_shake256_public_key(types.uint8_t_57, pri)
   return ffi_str(types.uint8_t_57, 57)
 end
 
-function ed.sign(pub, pri, msg)
-  if pri and not pub then
+function ed448.sign(pub, pri, msg)
+  if not pri then
+    return nil, "the EdDSA448 SHAKE-256 signing is not possible without private key"
+  end
+  if not pub then
     local err
-    pub, err = ed.public_key(pri)
+    pub, err = ed448.public_key(pri)
     if not pub then
       return nil, err
     end
@@ -33,7 +39,13 @@ function ed.sign(pub, pri, msg)
   return ffi_str(types.uint8_t_114, 114)
 end
 
-function ed.verify(pub, msg, sig)
+function ed448.verify(pub, msg, sig)
+  if not pub then
+    return nil, "the EdDSA448 SHAKE-256 signature verification is not possible without public key"
+  end
+  if not sig then
+    return nil, "the EdDSA448 SHAKE-256 signature verification is not possible without signature"
+  end
   if #pub ~= 57 then
     return nil, "the EdDSA448 SHAKE-256 supported public key size is 456 bits"
   end
@@ -46,4 +58,4 @@ function ed.verify(pub, msg, sig)
   return true
 end
 
-return ed
+return ed448

--- a/lib/resty/nettle/eddsa.lua
+++ b/lib/resty/nettle/eddsa.lua
@@ -1,2 +1,48 @@
-return require "resty.nettle.ed25519-sha512"
+local ed25519 = require "resty.nettle.ed25519-sha512"
+local ed448 = require "resty.nettle.ed448-shake256"
 
+local eddsa = {}
+
+function eddsa.public_key(pri)
+  if not pri then
+    return nil, "the EdDSA public key cannot be extracted without private key"
+  end
+  local len = #pri
+  if len == 32 then
+    return ed25519.public_key(pri)
+  elseif len == 57 then
+    return ed448.public_key(pri)
+  else
+    return nil, "the EdDSA supported private key sizes are 256 bits (Ed25519) and 456 bits (Ed448)"
+  end
+end
+
+function eddsa.sign(pub, pri, msg)
+  if not pri then
+    return nil, "the EdDSA signing is not possible without private key"
+  end
+  local len = #pri
+  if len == 32 then
+    return ed25519.sign(pub, pri, msg)
+  elseif len == 57 then
+    return ed448.sign(pub, pri, msg)
+  else
+    return nil, "the EdDSA supported private key sizes are 256 bits (Ed25519) and 456 bits (Ed448)"
+  end
+end
+
+function eddsa.verify(pub, msg, sig)
+  if not pub then
+    return nil, "the EdDSA signature verification is not possible without public key"
+  end
+  local len = #pub
+  if len == 32 then
+    return ed25519.verify(pub, msg, sig)
+  elseif len == 57 then
+    return ed448.verify(pub, msg, sig)
+  else
+    return nil, "the EdDSA supported public key sizes are 256 bits (Ed25519) and 456 bits (Ed448)"
+  end
+end
+
+return eddsa

--- a/lua-resty-nettle-2.1-1.rockspec
+++ b/lua-resty-nettle-2.1-1.rockspec
@@ -1,14 +1,15 @@
 rockspec_format = "3.0"
 package = "lua-resty-nettle"
-version = "dev-1"
+version = "2.1-1"
 source = {
   url = "git://github.com/bungle/lua-resty-nettle.git",
+  branch = "v2.1",
 }
+
 description = {
   summary    = "LuaJIT FFI bindings for Nettle (a low-level cryptographic library)",
   detailed   = "lua-resty-nettle contains LuaJIT FFI bindings to GNU Nettle cryptographic library.",
   homepage   = "https://github.com/bungle/lua-resty-nettle",
-  issues_url = "https://github.com/bungle/lua-resty-nettle/issues",
   maintainer = "Aapo Talvensaari <aapo.talvensaari@gmail.com>",
   license    = "BSD",
   labels     = {
@@ -132,5 +133,5 @@ build = {
     ["resty.nettle.padding.pkcs7"]         = "lib/resty/nettle/padding/pkcs7.lua",
     ["resty.nettle.padding.spacepadding"]  = "lib/resty/nettle/padding/spacepadding.lua",
     ["resty.nettle.padding.zeropadding"]   = "lib/resty/nettle/padding/zeropadding.lua",
-  }
+  },
 }


### PR DESCRIPTION
### Added
- Publish `resty.nettle.eddsa` module with `resty.nettle` module
- Make `resty.nettle.eddsa` to automatically choose the algorithm based on key size